### PR TITLE
change mailing-list address

### DIFF
--- a/foodsoft-hosting.md
+++ b/foodsoft-hosting.md
@@ -25,7 +25,7 @@ countries, and hosting costs are paid for by (yearly) donations. They'd be happy
 to welcome you on board.
 
 <a href="/global-foodsoft-platform" class="btn btn--inverse">Read more</a>
-<a href="mailto:foodcoops-support@lists.systemausfall.org" class="btn btn--inverse"><i class="fa fa-envelope"></i> Contact</a>
+<a href="mailto:foodcoops-support@wat.systemausfall.org" class="btn btn--inverse"><i class="fa fa-envelope"></i> Contact</a>
 
 ## Austria
 

--- a/global-foodsoft-platform.md
+++ b/global-foodsoft-platform.md
@@ -37,7 +37,7 @@ If you have a question about using Foodsoft, you can visit the [user mailing-lis
 Or maybe the [support wiki](https://github.com/foodcoops/foodsoft/wiki/Support) has what you need already.
 
 In case you have an issue with the global platform, you can send an email to
-[foodcoops-support@lists.systemausfall.org](mailto:foodcoops-support@lists.systemausfall.org),
+[foodcoops-support@wat.systemausfall.org](mailto:foodcoops-support@wat.systemausfall.org),
 where the technical team can help resolve it.
 
 # Helping out


### PR DESCRIPTION
This replaces #1 because I had to resolve merge conflicts.

I will merge this soon if you do not complain. The new mailing-list address shows up in several places that are visible to users. I think it is less confusing if we just switch to the new addresses.